### PR TITLE
More /entitycount options

### DIFF
--- a/src/main/java/net/simpvp/Misc/EntityCounts.java
+++ b/src/main/java/net/simpvp/Misc/EntityCounts.java
@@ -6,11 +6,22 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-public class EntityCounts implements CommandExecutor {
+public class EntityCounts implements CommandExecutor, TabCompleter {
 
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 
@@ -19,37 +30,137 @@ public class EntityCounts implements CommandExecutor {
 			return false;
 		}
 
-		String msg = Misc.instance.getServer().getOnlinePlayers().stream()
-				.collect(Collectors.toMap(Player::getName, EntityCounts::getEntityCount))
+		Map<String, Integer> counts;
+		String msg;
+
+		command:
+		switch(args.length) {
+			case 0:
+				counts = getAllEntityCounts(null);
+				msg = "Entity count:\n ";
+				break;
+			case 2:
+				switch(args[0]) {
+					case "type":
+						try {
+							EntityType type = EntityType.valueOf(args[1].toUpperCase());
+							counts = getAllEntityCounts(e -> e.getType() == type);
+							msg = args[1] + " count:\n ";
+							break command;
+						} catch (IllegalArgumentException e) {
+							sender.sendMessage(ChatColor.RED + "Unknown entity type: " + args[1]);
+							return false;
+						}
+					case "player":
+						Player target = Misc.instance.getServer().getPlayer(args[1]);
+						if (target != null) {
+							counts = detailedEntityCount(target);
+							msg = "Detailed entity count for " + args[1] + ":\n ";
+							break command;
+						} else {
+							sender.sendMessage(ChatColor.RED + "Player is not online.");
+							return false;
+						}
+				}
+			default:
+				sender.sendMessage(ChatColor.RED + "Usage: /entitycounts [type|player] [option]");
+				return false;
+		}
+
+		msg += counts
 				.entrySet().stream()
+				.filter(e -> e.getValue() > 0)
 				.sorted((a, b) -> b.getValue().compareTo(a.getValue()))
 				.map(e -> e.getKey() + ": " + e.getValue())
 				.collect(Collectors.joining(", "));
-
-		sender.sendMessage("Top players: " + msg);
+		sender.sendMessage(msg);
 		return true;
 	}
 
 	/**
-	 * @param player Player to check
-	 * @return All entities within the server view distance of player
+	 * Short form to run getEntityCount for all online players
+	 * @param matching Predicate to filter entities, can be set to null to return everything
+	 * @return Map of all players and the number of matched entities around them
 	 */
-	public static int getEntityCount(Player player) {
-		int count = 0;
+	private static Map<String, Integer> getAllEntityCounts(Predicate<Entity> matching) {
+		return Misc.instance.getServer().getOnlinePlayers().stream()
+				.collect(Collectors.toMap(Player::getName, p -> getEntityCount(p, matching)));
+	}
+
+	/**
+	 * Find number of entities near a player potentially matching some filter
+	 * @param player Player to check
+	 * @param matching Predicate to filter entities, can be set to null to return everything
+	 * @return Number of matched entities
+	 */
+	private static int getEntityCount(Player player, Predicate<Entity> matching) {
+		Stream<Chunk> chunks = getChunks(player).stream();
+		return (matching == null) ?
+				chunks.mapToInt(c -> c.getEntities().length).sum() :
+				chunks.mapToInt(c -> (int) (Arrays.stream(c.getEntities()).filter(matching).count())).sum();
+	}
+
+	/**
+	 * Get detailed count of all different entity types near a specific player
+	 * @param player Player to check
+	 * @return Map of all found entity types and their count
+	 */
+	private static Map<String, Integer> detailedEntityCount(Player player) {
+		HashMap<String, Integer> counts = new HashMap<>();
+		getChunks(player).stream()
+				.flatMap(c -> Arrays.stream(c.getEntities()))
+				.forEach(entity -> counts.merge(entity.getType().name().toLowerCase(), 1, Integer::sum));
+		return counts;
+	}
+
+	/**
+	 * Get all chunks around a player within server view distance
+	 * @param player Player to find chunks
+	 * @return All nearby chunks
+	 */
+	private static List<Chunk> getChunks(Player player) {
+		List<Chunk> chunks = new ArrayList<>();
 		World world = player.getWorld();
 		Chunk mid = player.getLocation().getChunk();
 		int midX = mid.getX();
 		int midZ = mid.getZ();
 		int dist = Misc.instance.getServer().getViewDistance();
 
-		for (int x = -dist; x < dist; x++) {
-			for (int z = -dist; z < dist; z++) {
-				Chunk c = world.getChunkAt(midX + x, midZ + z);
-				/* This could be filtered down to only living entities or specifically laggy ones such as villagers
-				   but it should be good enough to give a general idea of who is causing lag. */
-				count += c.getEntities().length;
+		for (int x = -dist; x <= dist; x++) {
+			for (int z = -dist; z <= dist; z++) {
+				chunks.add(world.getChunkAt(midX + x, midZ + z));
 			}
 		}
-		return count;
+		return chunks;
+	}
+
+	private static final List<String> entityTypeList = Arrays.stream(EntityType.values())
+			.map(e -> e.name().toLowerCase())
+			.collect(Collectors.toList());
+
+	@Override
+	public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
+		if (!sender.isOp()) return null;
+
+		String typing = args[args.length-1];
+		switch(args.length) {
+			case 1: return autoComplete(typing, Arrays.asList("type", "player"));
+			case 2:
+				switch (args[0]) {
+					case "type": return autoComplete(typing, entityTypeList);
+					case "player": return null; // Returning null shows tab completions for online player names
+				}
+			default: return new ArrayList<>(); // Returning an empty list shows no tab completions
+		}
+	}
+
+	/**
+	 * Gives autocomplete suggestion for passed argument and list of valid options
+	 * @param arg Current argument being typed
+	 * @param list List of options, such as all entity types
+	 * @return List of matching options from what is typed so far
+	 */
+	private static List<String> autoComplete(String arg, List<String> list) {
+		return StringUtil.copyPartialMatches(arg, list, new ArrayList<>());
 	}
 }

--- a/src/main/java/net/simpvp/Misc/Misc.java
+++ b/src/main/java/net/simpvp/Misc/Misc.java
@@ -46,7 +46,9 @@ public class Misc extends JavaPlugin {
 		getCommand("checkonline").setExecutor(oc_instance);
 		getCommand("on").setExecutor(oc_instance);
 		getServer().getPluginManager().registerEvents(nnp_instance, this);
-		getCommand("entitycounts").setExecutor(new EntityCounts());
+		EntityCounts ec_instance = new EntityCounts();
+		getCommand("entitycounts").setExecutor(ec_instance);
+		getCommand("entitycounts").setTabCompleter(ec_instance);
 
 		Thunder.add_protocol_listeners();
 		this.getConfig().options().copyDefaults(true);


### PR DESCRIPTION
Previous usage of just `/entitycount` works the same, but added options to display counts for specific entities with `/entitycount type <EntityType>` and a detailed breakdown of a specific player with `/entitycount player <username>`