### PR TITLE
Add option to disable specific players from using /cancelrestart

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,3 +7,4 @@ oponlyCmds: []
 blockLogWorlds: []
 projectileOwnerMaxDistance: 300
 disableElderGuardians: []
+disableCancelRestart: []

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -22,7 +22,7 @@ public class Restart implements CommandExecutor {
 	private static long last_request = System.currentTimeMillis();
 
 	// This is a list of players who can't use /cancelrestart
-	List<UUID> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
+	List<?> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
 	
 	public boolean onCommand(CommandSender sender,
 			Command cmd,
@@ -124,4 +124,3 @@ public class Restart implements CommandExecutor {
 	}
 
 }
-

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -95,7 +95,7 @@ public class Restart implements CommandExecutor {
 			} else if (requester != null && player != null &&
 					requester.equals(player.getUniqueId())) {
 				sender.sendMessage(ChatColor.RED + "You cannot cancel a restart you requested.");
-			} else if (cancel.contains(player.getUniqueId())) {
+			} else if (cancel.contains(player.getUniqueId().toString())) {
 				sender.sendMessage(ChatColor.RED + "You can no longer use this command.");
 			} else {
 				cancelled = true;

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.List;
 import java.util.UUID;
 
 public class Restart implements CommandExecutor {
@@ -20,6 +21,9 @@ public class Restart implements CommandExecutor {
 	private static UUID requester = null;
 	private static long last_request = System.currentTimeMillis();
 
+	// This is a list of players who can't use /cancelrestart
+	List<?> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
+	
 	public boolean onCommand(CommandSender sender,
 			Command cmd,
 			String label,
@@ -87,10 +91,12 @@ public class Restart implements CommandExecutor {
 
 		} else if (cmd.getName().equals("cancelrestart")) {
 			if (cancelled == true) {
-				sender.sendMessage("There is no restart for you to cancel.");
+				sender.sendMessage(ChatColor.RED + "There is no restart for you to cancel.");
 			} else if (requester != null && player != null &&
 					requester.equals(player.getUniqueId())) {
-				sender.sendMessage("You cannot cancel a restart you requested.");
+				sender.sendMessage(ChatColor.RED + "You cannot cancel a restart you requested.");
+			} else if (cancel.contains(player.getName())) {
+				sender.sendMessage(ChatColor.RED + "You can no longer use this command.");
 			} else {
 				cancelled = true;
 				String msg = "[Announcement] " + sender.getName() + " has cancelled the requested server restart. Tip: Ask in chat if anybody minds a restart before initiating one.";

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -22,7 +22,7 @@ public class Restart implements CommandExecutor {
 	private static long last_request = System.currentTimeMillis();
 
 	// This is a list of players who can't use /cancelrestart
-	List<?> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
+	List<UUID> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
 	
 	public boolean onCommand(CommandSender sender,
 			Command cmd,
@@ -95,7 +95,7 @@ public class Restart implements CommandExecutor {
 			} else if (requester != null && player != null &&
 					requester.equals(player.getUniqueId())) {
 				sender.sendMessage(ChatColor.RED + "You cannot cancel a restart you requested.");
-			} else if (cancel.contains(player.getUniqueId().toString())) {
+			} else if (cancel.contains(player.getUniqueId())) {
 				sender.sendMessage(ChatColor.RED + "You can no longer use this command.");
 			} else {
 				cancelled = true;

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -95,7 +95,7 @@ public class Restart implements CommandExecutor {
 			} else if (requester != null && player != null &&
 					requester.equals(player.getUniqueId())) {
 				sender.sendMessage(ChatColor.RED + "You cannot cancel a restart you requested.");
-			} else if (cancel.contains(player.getName())) {
+			} else if (cancel.contains(player.getUniqueId())) {
 				sender.sendMessage(ChatColor.RED + "You can no longer use this command.");
 			} else {
 				cancelled = true;

--- a/src/main/java/net/simpvp/Misc/Restart.java
+++ b/src/main/java/net/simpvp/Misc/Restart.java
@@ -22,7 +22,7 @@ public class Restart implements CommandExecutor {
 	private static long last_request = System.currentTimeMillis();
 
 	// This is a list of players who can't use /cancelrestart
-	List<?> cancel = Misc.instance.getConfig().getList("disableCancelRestart");
+	List<?> cancel = Misc.instance.getConfig().getStringList("disableCancelRestart").stream().map(UUID::fromString).collect(java.util.stream.Collectors.toList());
 	
 	public boolean onCommand(CommandSender sender,
 			Command cmd,
@@ -124,3 +124,4 @@ public class Restart implements CommandExecutor {
 	}
 
 }
+


### PR DESCRIPTION
Using uuids might be better than player names. I think this should work but I haven't tested it much