### PR TITLE
Add blue skull activation range

### DIFF
--- a/src/main/java/net/simpvp/Misc/BlueSkulls.java
+++ b/src/main/java/net/simpvp/Misc/BlueSkulls.java
@@ -1,0 +1,31 @@
+package net.simpvp.Misc;
+
+import org.bukkit.Location;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+
+public class BlueSkulls implements Listener {
+	private static final int ACTIVATION_MINIMUM = 32 * 32;
+
+	/**
+	 * Prevent explosion damage from blue wither skulls if no player is nearby.
+	 */
+	@EventHandler
+	public void onEntityExplode(EntityExplodeEvent event) {
+		if (!(event.getEntity() instanceof WitherSkull))
+			return;
+
+		WitherSkull skull = (WitherSkull) event.getEntity();
+		if (!skull.isCharged())
+			return; // Not blue skull
+
+		Location loc = event.getLocation();
+		boolean hasNearby = loc.getWorld().getPlayers().stream()
+				.anyMatch(p -> p.getLocation().distanceSquared(loc) < ACTIVATION_MINIMUM);
+
+		if (!hasNearby)
+			event.setCancelled(true);
+	}
+}

--- a/src/main/java/net/simpvp/Misc/Misc.java
+++ b/src/main/java/net/simpvp/Misc/Misc.java
@@ -37,6 +37,7 @@ public class Misc extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new DamageSource(this.getConfig().getInt("projectileOwnerMaxDistance")), this);
 		getServer().getPluginManager().registerEvents(new Announcement(this), this);
 		getServer().getPluginManager().registerEvents(new EnderPearlTeleports(), this);
+		getServer().getPluginManager().registerEvents(new BlueSkulls(), this);
 		getCommand("coords").setExecutor(new CoordsForAll());
 		getCommand("f").setExecutor(new Follow());
 		getCommand("b").setExecutor(new Follow());


### PR DESCRIPTION
Stops blue wither skulls (the ones that can break all blocks) from damaging terrain if a player isn't nearby. Should cut down on the damage around spawn without affecting gameplay much.