### PR TITLE
Revert pigman drop changes

### DIFF
--- a/src/main/java/net/simpvp/Misc/Misc.java
+++ b/src/main/java/net/simpvp/Misc/Misc.java
@@ -38,6 +38,7 @@ public class Misc extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new Announcement(this), this);
 		getServer().getPluginManager().registerEvents(new EnderPearlTeleports(), this);
 		getServer().getPluginManager().registerEvents(new BlueSkulls(), this);
+		getServer().getPluginManager().registerEvents(new PigmanDropFix(), this);
 		getCommand("coords").setExecutor(new CoordsForAll());
 		getCommand("f").setExecutor(new Follow());
 		getCommand("b").setExecutor(new Follow());

--- a/src/main/java/net/simpvp/Misc/PigmanDropFix.java
+++ b/src/main/java/net/simpvp/Misc/PigmanDropFix.java
@@ -1,0 +1,48 @@
+package net.simpvp.Misc;
+
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.PigZombie;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class PigmanDropFix implements Listener {
+
+	private static final int ADULT_XP = 5;
+	private static final int BABY_XP = 12;
+	private static final float INGOT_CHANCE = 0.025f;
+
+	/**
+	 * Reverts the 1.21.5 Zombified Piglin drop changes.
+	 * See: https://bugs.mojang.com/browse/MC/issues/MC-56653
+	 */
+	@EventHandler
+	public void onEntityDeath(EntityDeathEvent event) {
+		if (event.getEntityType() != EntityType.ZOMBIFIED_PIGLIN)
+			return;
+
+		PigZombie pigman = (PigZombie) event.getEntity();
+
+		if (!pigman.isAngry() || event.getDroppedExp() > 0)
+			return;
+
+		// Experience
+		int droppedExp = pigman.isAdult() ? ADULT_XP : BABY_XP;
+		event.setDroppedExp(droppedExp);
+
+		// Gold ingot
+		if (Math.random() < INGOT_CHANCE) {
+			ItemStack ingot = new ItemStack(Material.GOLD_INGOT, 1);
+			event.getDrops().add(ingot);
+		}
+
+		// Mainhand weapon
+		ItemStack weapon = pigman.getEquipment().getItemInMainHand();
+		float chance = pigman.getEquipment().getItemInMainHandDropChance();
+		if (weapon != null && Math.random() < chance) {
+			event.getDrops().add(weapon);
+		}
+	}
+}


### PR DESCRIPTION
Reverts pigmen back to the pre-1.21.5 behavior where they drop xp and ingots when angry even if not killed by a player.